### PR TITLE
Add `-CAfile` to run_server.sh

### DIFF
--- a/proof-of-concept-exploits/openssl-punycode-vulnerability/malicious_server/server/run_server.sh
+++ b/proof-of-concept-exploits/openssl-punycode-vulnerability/malicious_server/server/run_server.sh
@@ -1,1 +1,1 @@
-../openssl/apps/openssl s_server -accept 127.0.0.1:3000 -cert certs/trusted.pem -key certs/server.key.pem -state
+../openssl/apps/openssl s_server -accept 127.0.0.1:3000 -CAfile certs/cacert.pem -cert certs/trusted.pem -key certs/server.key.pem -state


### PR DESCRIPTION
Specifying `s_server -cert certs/trusted.pem` alone does not send the full certificate chain.
The option `-CAfile certs/cacert.pem` is required to also send the root certificate.